### PR TITLE
Refactor backend with service layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Une application de gestion de tâches élégante et efficace, avec un backend Ex
 - [Installation](#installation)
 - [Utilisation](#utilisation)
 - [Configuration](#configuration)
-- [Fonctionnalités](#fonctionnalités)
+- [Fonctionnalités](#fonctionnalites-a-implementer)
 - [Contributions](#contributions)
 - [Auteurs](#auteurs)
 - [Licence](#licence)
@@ -61,12 +61,26 @@ Visitez `http://localhost:3000` dans votre navigateur pour accéder à l'interfa
 ## Configuration
 
 Assurez-vous de créer un fichier `.env` à la racine de backend et frontend pour définir toutes les variables d'environnement nécessaires.
-Fonctionnalités
 
-- Gestion des utilisateurs (inscription, connexion).
-- Création et suivi des tâches.
-- Gestion des projets.
-- Attribution des rôles.
+## Fonctionnalités à implémenter
+
+### Backend
+
+- Authentification via JWT : inscription, connexion, déconnexion et réinitialisation du mot de passe.
+- Gestion complète des utilisateurs (création, lecture, mise à jour et suppression) avec assignation de rôles.
+- Gestion des tâches (CRUD) avec suivi de statut et assignation aux utilisateurs.
+- Gestion des projets (CRUD) permettant d'organiser les tâches par projet.
+- Téléversement de fichiers et d'avatars via `multer`.
+- Validation des données avec `express-validator`.
+- Gestion centralisée des erreurs et réponses uniformes au format `{ status: true, message: "Création réussi", error: [] }`.
+- Utilisation de design patterns (services, repositories, middlewares) pour structurer le code.
+- Refactorisation globale du backend pour séparer la logique métier et faciliter la maintenance.
+- Mise en place de tests automatisés avec Jest et Supertest.
+
+### Frontend
+
+- Interfaces React pour la gestion des utilisateurs, des projets et des tâches.
+- Consommation des API du backend et affichage des retours au format précédent.
 
 ## Contributions
 

--- a/backend/controllers/projectController.js
+++ b/backend/controllers/projectController.js
@@ -1,12 +1,11 @@
 // backend/controllers/projectController.js
-const Project = require('../models/project');
-const { translateStatus, translateImportance } = require('../utils/translationHelper');
+const ProjectService = require('../services/projectService');
 const projectController = {};
 
 // Obtenir tous les projets
 projectController.getAllProjects = async (req, res) => {
     try {
-        const projects = await Project.findAll();
+        const projects = await ProjectService.getAll();
         res.status(200).json({ success: true, message: "Projets récupérés avec succès", data: projects });
     } catch (error) {
         res.status(500).json({ success: false, message: "Erreur lors de la récupération des projets." });
@@ -16,11 +15,8 @@ projectController.getAllProjects = async (req, res) => {
 // Obtenir un projet par ID
 projectController.getProjectById = async (req, res) => {
     try {
-        const project = await Project.findByPk(req.params.id);
+        const project = await ProjectService.getById(req.params.id);
         if (project) {
-            // Traduire le statut et l'importance en français pour la réponse
-            project.status = translateStatus(project.status);
-            project.importance = translateImportance(project.importance);
             res.status(200).json({ success: true, message: "Projet récupéré avec succès", data: project });
         } else {
             res.status(404).json({ success: false, message: "Projet non trouvé." });
@@ -33,7 +29,7 @@ projectController.getProjectById = async (req, res) => {
 // Créer un nouveau projet
 projectController.createProject = async (req, res) => {
     try {
-        const project = await Project.create(req.body);
+        const project = await ProjectService.create(req.body);
         res.status(201).json({ success: true, message: "Projet créé avec succès", data: project });
     } catch (error) {
         res.status(500).json({ success: false, message: "Erreur lors de la création du projet." });
@@ -43,9 +39,8 @@ projectController.createProject = async (req, res) => {
 // Mettre à jour un projet
 projectController.updateProject = async (req, res) => {
     try {
-        const project = await Project.findByPk(req.params.id);
+        const project = await ProjectService.update(req.params.id, req.body);
         if (project) {
-            await project.update(req.body);
             res.status(200).json({ success: true, message: "Projet mis à jour avec succès", data: project });
         } else {
             res.status(404).json({ success: false, message: "Projet non trouvé." });
@@ -58,9 +53,8 @@ projectController.updateProject = async (req, res) => {
 // Supprimer un projet
 projectController.deleteProject = async (req, res) => {
     try {
-        const project = await Project.findByPk(req.params.id);
+        const project = await ProjectService.remove(req.params.id);
         if (project) {
-            await project.destroy();
             res.status(200).json({ success: true, message: "Projet supprimé avec succès." });
         } else {
             res.status(404).json({ success: false, message: "Projet non trouvé." });

--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -1,13 +1,13 @@
 // backend/controllers/taskController.js
 
-const Task = require('../models/task');
+const TaskService = require('../services/taskService');
 
 const taskController = {};
 
 // Obtenir toutes les tâches
 taskController.getAllTasks = async (req, res) => {
     try {
-        const tasks = await Task.findAll();
+        const tasks = await TaskService.getAll();
         res.status(200).json({ success: true, message: "Tâches récupérées avec succès", data: tasks });
     } catch (error) {
         res.status(500).json({ success: false, message: "Erreur lors de la récupération des tâches." });
@@ -17,7 +17,7 @@ taskController.getAllTasks = async (req, res) => {
 // Obtenir une tâche par ID
 taskController.getTaskById = async (req, res) => {
     try {
-        const task = await Task.findByPk(req.params.id);
+        const task = await TaskService.getById(req.params.id);
         if (task) {
             res.status(200).json({ success: true, message: "Tâche récupérée avec succès", data: task });
         } else {
@@ -31,7 +31,7 @@ taskController.getTaskById = async (req, res) => {
 // Créer une nouvelle tâche
 taskController.createTask = async (req, res) => {
     try {
-        const task = await Task.create(req.body);
+        const task = await TaskService.create(req.body);
         res.status(201).json({ success: true, message: "Tâche créée avec succès", data: task });
     } catch (error) {
         res.status(500).json({ success: false, message: "Erreur lors de la création de la tâche." });
@@ -41,9 +41,8 @@ taskController.createTask = async (req, res) => {
 // Mettre à jour une tâche
 taskController.updateTask = async (req, res) => {
     try {
-        const task = await Task.findByPk(req.params.id);
+        const task = await TaskService.update(req.params.id, req.body);
         if (task) {
-            await task.update(req.body);
             res.status(200).json({ success: true, message: "Tâche mise à jour avec succès", data: task });
         } else {
             res.status(404).json({ success: false, message: "Tâche non trouvée." });
@@ -56,9 +55,8 @@ taskController.updateTask = async (req, res) => {
 // Supprimer une tâche
 taskController.deleteTask = async (req, res) => {
     try {
-        const task = await Task.findByPk(req.params.id);
+        const task = await TaskService.remove(req.params.id);
         if (task) {
-            await task.destroy();
             res.status(200).json({ success: true, message: "Tâche supprimée avec succès." });
         } else {
             res.status(404).json({ success: false, message: "Tâche non trouvée." });

--- a/backend/services/projectService.js
+++ b/backend/services/projectService.js
@@ -1,0 +1,37 @@
+const Project = require('../models/project');
+const { translateStatus, translateImportance } = require('../utils/translationHelper');
+
+const ProjectService = {
+    async getAll() {
+        return await Project.findAll();
+    },
+
+    async getById(id) {
+        const project = await Project.findByPk(id);
+        if (project) {
+            project.status = translateStatus(project.status);
+            project.importance = translateImportance(project.importance);
+        }
+        return project;
+    },
+
+    async create(data) {
+        return await Project.create(data);
+    },
+
+    async update(id, data) {
+        const project = await Project.findByPk(id);
+        if (!project) return null;
+        await project.update(data);
+        return project;
+    },
+
+    async remove(id) {
+        const project = await Project.findByPk(id);
+        if (!project) return null;
+        await project.destroy();
+        return project;
+    }
+};
+
+module.exports = ProjectService;

--- a/backend/services/taskService.js
+++ b/backend/services/taskService.js
@@ -1,0 +1,31 @@
+const Task = require('../models/task');
+
+const TaskService = {
+    async getAll() {
+        return await Task.findAll();
+    },
+
+    async getById(id) {
+        return await Task.findByPk(id);
+    },
+
+    async create(data) {
+        return await Task.create(data);
+    },
+
+    async update(id, data) {
+        const task = await Task.findByPk(id);
+        if (!task) return null;
+        await task.update(data);
+        return task;
+    },
+
+    async remove(id) {
+        const task = await Task.findByPk(id);
+        if (!task) return null;
+        await task.destroy();
+        return task;
+    }
+};
+
+module.exports = TaskService;

--- a/backend/services/userService.js
+++ b/backend/services/userService.js
@@ -1,0 +1,49 @@
+const User = require('../models/user');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+
+const UserService = {
+    async getAll() {
+        return await User.findAll();
+    },
+
+    async getById(id) {
+        return await User.findByPk(id);
+    },
+
+    async create(data) {
+        return await User.create(data);
+    },
+
+    async update(id, data) {
+        const user = await User.findByPk(id);
+        if (!user) return null;
+        await user.update(data);
+        return user;
+    },
+
+    async remove(id) {
+        const user = await User.findByPk(id);
+        if (!user) return null;
+        await user.destroy();
+        return user;
+    },
+
+    async signup(data) {
+        data.role_id = 2;
+        const user = await User.create(data);
+        const token = jwt.sign({ userId: user.id, email: user.email }, process.env.JWT_SECRET, { expiresIn: '1h' });
+        return { user, token };
+    },
+
+    async login(credentials) {
+        const user = await User.findOne({ where: { email: credentials.email } });
+        if (user && bcrypt.compareSync(credentials.mot_de_passe, user.mot_de_passe)) {
+            const token = jwt.sign({ userId: user.id, email: user.email }, process.env.JWT_SECRET, { expiresIn: '1h' });
+            return { token };
+        }
+        return null;
+    }
+};
+
+module.exports = UserService;


### PR DESCRIPTION
## Summary
- refactor controllers to delegate business logic to new services
- add TaskService, ProjectService and UserService for DB operations
- update controller imports to use the services

## Testing
- `npm test` in `backend` *(fails: no test specified)*
- `npm test -- -w 1` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848378ec3b8832a8b680a0b6b0ad66a