### PR TITLE
Add frontend components for tasks and users

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,6 +20,8 @@ const HomePage = React.lazy(() =>
   )
 );
 const ProjectsPage = React.lazy(() => import('./views/ProjectsPage'));
+const TasksPage = React.lazy(() => import('./views/TasksPage'));
+const UsersPage = React.lazy(() => import('./views/UsersPage'));
 const AuthView = React.lazy(() => import('./views/AuthView'));
 
 function App() {
@@ -39,6 +41,8 @@ function App() {
               </div>}>
               <Routes>
                 <Route path="/project-list" element={<ProjectsPage />} />
+                <Route path="/task-list" element={<TasksPage />} />
+                <Route path="/user-list" element={<UsersPage />} />
                 <Route path="/auth" element={<AuthView />} />
                 <Route path="/" element={<HomePage />} />
               </Routes>

--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -53,6 +53,7 @@ function Header() {
                         <>
                             <Link className="nav-link me-3" to="/project-list">Projets</Link>
                             <Link className="nav-link me-3" to="/task-list">Tâches</Link>
+                            <Link className="nav-link me-3" to="/user-list">Utilisateurs</Link>
                         </>
                     )}
                     <Link className="nav-link me-3" to="/about">À propos</Link>

--- a/frontend/src/components/Task/CreateTask.js
+++ b/frontend/src/components/Task/CreateTask.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import TaskForm from './TaskForm';
 
-function CreateTask() {
-    return <div>Créer une nouvelle tâche</div>;
+function CreateTask({ onSuccess }) {
+    return <TaskForm onSuccess={onSuccess} />;
 }
 
 export default CreateTask;

--- a/frontend/src/components/Task/DeleteTask.js
+++ b/frontend/src/components/Task/DeleteTask.js
@@ -1,7 +1,23 @@
 import React from 'react';
+import { Button } from 'react-bootstrap';
+import api from '../../services/api';
 
-function DeleteTask() {
-    return <div>Supprimer la tâche</div>;
+function DeleteTask({ taskId, onDeleted }) {
+    const handleDelete = async () => {
+        if (!window.confirm('Supprimer cette tâche ?')) return;
+        try {
+            await api.delete(`/tasks/${taskId}`);
+            onDeleted && onDeleted();
+        } catch (err) {
+            alert('Erreur lors de la suppression');
+        }
+    };
+
+    return (
+        <Button variant="danger" size="sm" onClick={handleDelete}>
+            Supprimer
+        </Button>
+    );
 }
 
 export default DeleteTask;

--- a/frontend/src/components/Task/EditTask.js
+++ b/frontend/src/components/Task/EditTask.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import TaskForm from './TaskForm';
 
-function EditTask() {
-    return <div>Éditer la tâche</div>;
+function EditTask({ task, onSuccess }) {
+    return <TaskForm taskData={task} onSuccess={onSuccess} />;
 }
 
 export default EditTask;

--- a/frontend/src/components/Task/TaskDetail.js
+++ b/frontend/src/components/Task/TaskDetail.js
@@ -1,7 +1,49 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { Card, Spinner, Alert } from 'react-bootstrap';
+import api from '../../services/api';
 
 function TaskDetail() {
-    return <div>Détail de la tâche</div>;
+    const { id } = useParams();
+    const [task, setTask] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        api.get(`/tasks/${id}`)
+            .then(res => {
+                setTask(res.data.data);
+                setLoading(false);
+            })
+            .catch(() => {
+                setError('Erreur lors de la récupération de la tâche');
+                setLoading(false);
+            });
+    }, [id]);
+
+    if (loading) {
+        return (
+            <div className="d-flex justify-content-center margin-top-10">
+                <Spinner animation="border" variant="primary" role="status" />
+            </div>
+        );
+    }
+
+    if (error) {
+        return <Alert variant="danger">{error}</Alert>;
+    }
+
+    if (!task) return null;
+
+    return (
+        <Card className="mt-3 w-50 mx-auto">
+            <Card.Body>
+                <Card.Title>{task.libelle}</Card.Title>
+                <Card.Text>{task.description}</Card.Text>
+                <Card.Text>Statut : {task.status}</Card.Text>
+            </Card.Body>
+        </Card>
+    );
 }
 
 export default TaskDetail;

--- a/frontend/src/components/Task/TaskForm.js
+++ b/frontend/src/components/Task/TaskForm.js
@@ -1,0 +1,95 @@
+import React, { useState, useEffect } from 'react';
+import { Form, Button, Row, Col, Alert } from 'react-bootstrap';
+import api from '../../services/api';
+
+function TaskForm({ onSuccess, taskData }) {
+    const [task, setTask] = useState(taskData || {
+        libelle: '',
+        description: '',
+        status: 'pending',
+        delai: '',
+        porteur_id: '',
+        projet_id: ''
+    });
+    const [error, setError] = useState(null);
+
+    const handleInputChange = e => {
+        const { name, value } = e.target;
+        setTask(prev => ({ ...prev, [name]: value }));
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        try {
+            let response;
+            if (taskData) {
+                response = await api.put(`/tasks/${taskData.id}`, task);
+            } else {
+                response = await api.post('/tasks', task);
+            }
+            if (response.data.success) {
+                onSuccess && onSuccess();
+                setTask({ libelle: '', description: '', status: 'pending', delai: '', porteur_id: '', projet_id: '' });
+            } else {
+                setError(response.data.message || "Une erreur est survenue.");
+            }
+        } catch (err) {
+            setError("Une erreur est survenue lors de l'envoi des données.");
+        }
+    };
+
+    return (
+        <Form onSubmit={handleSubmit} className="w-50 mx-auto mt-3">
+            {error && <Alert variant="danger">{error}</Alert>}
+            <Form.Group as={Row} className="mb-3">
+                <Form.Label column sm={3} className="fw-bolder">Libellé</Form.Label>
+                <Col sm={9}>
+                    <Form.Control type="text" name="libelle" value={task.libelle} onChange={handleInputChange} required />
+                </Col>
+            </Form.Group>
+            <Form.Group as={Row} className="mb-3">
+                <Form.Label column sm={3} className="fw-bolder">Description</Form.Label>
+                <Col sm={9}>
+                    <Form.Control as="textarea" name="description" value={task.description} onChange={handleInputChange} />
+                </Col>
+            </Form.Group>
+            <Form.Group as={Row} className="mb-3">
+                <Form.Label column sm={3} className="fw-bolder">Statut</Form.Label>
+                <Col sm={9}>
+                    <Form.Select name="status" value={task.status} onChange={handleInputChange} required>
+                        <option value="pending">En attente</option>
+                        <option value="in_progress">En cours</option>
+                        <option value="completed">Terminée</option>
+                    </Form.Select>
+                </Col>
+            </Form.Group>
+            <Form.Group as={Row} className="mb-3">
+                <Form.Label column sm={3} className="fw-bolder">Délai</Form.Label>
+                <Col sm={9}>
+                    <Form.Control type="date" name="delai" value={task.delai} onChange={handleInputChange} />
+                </Col>
+            </Form.Group>
+            <Form.Group as={Row} className="mb-3">
+                <Form.Label column sm={3} className="fw-bolder">Porteur ID</Form.Label>
+                <Col sm={9}>
+                    <Form.Control type="number" name="porteur_id" value={task.porteur_id} onChange={handleInputChange} />
+                </Col>
+            </Form.Group>
+            <Form.Group as={Row} className="mb-3">
+                <Form.Label column sm={3} className="fw-bolder">Projet ID</Form.Label>
+                <Col sm={9}>
+                    <Form.Control type="number" name="projet_id" value={task.projet_id} onChange={handleInputChange} required />
+                </Col>
+            </Form.Group>
+            <Row className="justify-content-center my-4">
+                <Col md={6} className="text-center">
+                    <Button className="fw-medium w-100" type="submit" variant="primary">
+                        {taskData ? 'Mettre à jour' : 'Créer'}
+                    </Button>
+                </Col>
+            </Row>
+        </Form>
+    );
+}
+
+export default TaskForm;

--- a/frontend/src/components/Task/TaskList.js
+++ b/frontend/src/components/Task/TaskList.js
@@ -1,7 +1,79 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { Table, Button, Spinner, Alert } from 'react-bootstrap';
+import api from '../../services/api';
 
-function TaskList() {
-    return <div>Liste des tâches</div>;
+function TaskList({ onEdit }) {
+    const [tasks, setTasks] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    const fetchTasks = () => {
+        api.get('/tasks')
+            .then(response => {
+                setTasks(response.data.data);
+                setLoading(false);
+            })
+            .catch(err => {
+                setError('Erreur lors de la récupération des tâches');
+                setLoading(false);
+            });
+    };
+
+    useEffect(() => {
+        fetchTasks();
+    }, []);
+
+    const handleDelete = async (id) => {
+        if (!window.confirm('Supprimer cette tâche ?')) return;
+        try {
+            await api.delete(`/tasks/${id}`);
+            fetchTasks();
+        } catch (err) {
+            setError('Erreur lors de la suppression');
+        }
+    };
+
+    if (loading) {
+        return (
+            <div className="d-flex justify-content-center margin-top-10">
+                <Spinner animation="border" variant="primary" role="status" />
+            </div>
+        );
+    }
+
+    if (error) {
+        return <Alert variant="danger">{error}</Alert>;
+    }
+
+    return (
+        <Table striped bordered hover>
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Libellé</th>
+                    <th>Statut</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {tasks.map(task => (
+                    <tr key={task.id}>
+                        <td>{task.id}</td>
+                        <td>{task.libelle}</td>
+                        <td>{task.status}</td>
+                        <td>
+                            <Button variant="warning" size="sm" className="me-2" onClick={() => onEdit(task)}>
+                                Éditer
+                            </Button>
+                            <Button variant="danger" size="sm" onClick={() => handleDelete(task.id)}>
+                                Supprimer
+                            </Button>
+                        </td>
+                    </tr>
+                ))}
+            </tbody>
+        </Table>
+    );
 }
 
 export default TaskList;

--- a/frontend/src/components/User/UserList.js
+++ b/frontend/src/components/User/UserList.js
@@ -1,7 +1,56 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { Table, Spinner, Alert } from 'react-bootstrap';
+import api from '../../services/api';
 
 function UserList() {
-    return <div>Liste des utilisateurs</div>;
+    const [users, setUsers] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        api.get('/users')
+            .then(res => {
+                setUsers(res.data.data);
+                setLoading(false);
+            })
+            .catch(() => {
+                setError('Erreur lors de la récupération des utilisateurs');
+                setLoading(false);
+            });
+    }, []);
+
+    if (loading) {
+        return (
+            <div className="d-flex justify-content-center margin-top-10">
+                <Spinner animation="border" variant="primary" role="status" />
+            </div>
+        );
+    }
+
+    if (error) {
+        return <Alert variant="danger">{error}</Alert>;
+    }
+
+    return (
+        <Table striped bordered hover>
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Nom</th>
+                    <th>Email</th>
+                </tr>
+            </thead>
+            <tbody>
+                {users.map(user => (
+                    <tr key={user.id}>
+                        <td>{user.id}</td>
+                        <td>{user.prenom} {user.nom}</td>
+                        <td>{user.email}</td>
+                    </tr>
+                ))}
+            </tbody>
+        </Table>
+    );
 }
 
 export default UserList;

--- a/frontend/src/views/TasksPage.js
+++ b/frontend/src/views/TasksPage.js
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { Collapse, Button, Row, Col } from 'react-bootstrap';
+import TaskList from '../components/Task/TaskList';
+import CreateTask from '../components/Task/CreateTask';
+import EditTask from '../components/Task/EditTask';
+
+function TasksPage() {
+    const [isAdding, setIsAdding] = useState(false);
+    const [editingTask, setEditingTask] = useState(null);
+    const [forceRefresh, setForceRefresh] = useState(false);
+
+    const handleSuccess = () => {
+        setIsAdding(false);
+        setEditingTask(null);
+        setForceRefresh(!forceRefresh);
+    };
+
+    return (
+        <>
+            <Row className="align-items-center my-1">
+                <Col className="text-end">
+                    <Button
+                        onClick={() => { setIsAdding(!isAdding); setEditingTask(null); }}
+                        aria-controls="task-collapse-text"
+                        aria-expanded={isAdding}
+                        className="me-3"
+                    >
+                        <i className={isAdding ? 'bi bi-x-circle-fill' : 'bi bi-plus-circle-fill'}></i>
+                        <span className="d-none d-lg-inline">{isAdding ? 'Retour à la liste' : 'Ajouter une tâche'}</span>
+                    </Button>
+                </Col>
+            </Row>
+            <Collapse in={!isAdding && !editingTask} dimension="height">
+                <div id="task-collapse-text">
+                    <TaskList key={forceRefresh} onEdit={(task) => { setEditingTask(task); setIsAdding(false); }} />
+                </div>
+            </Collapse>
+
+            <Collapse in={isAdding} dimension="height">
+                <div id="task-form-text">
+                    <CreateTask onSuccess={handleSuccess} />
+                </div>
+            </Collapse>
+
+            <Collapse in={!!editingTask} dimension="height">
+                <div id="task-edit-text">
+                    {editingTask && <EditTask task={editingTask} onSuccess={handleSuccess} />}
+                </div>
+            </Collapse>
+        </>
+    );
+}
+
+export default TasksPage;

--- a/frontend/src/views/UsersPage.js
+++ b/frontend/src/views/UsersPage.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import UserList from '../components/User/UserList';
+
+function UsersPage() {
+    return <UserList />;
+}
+
+export default UsersPage;


### PR DESCRIPTION
## Summary
- implement task CRUD components and pages
- add user list page
- wire new pages into router and navigation

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test --silent` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68488293917c832a9a693bb0fe017634